### PR TITLE
feat: update reactor creation for generic oracle adapters

### DIFF
--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -25,7 +25,6 @@ interface ReactorConfig {
   protonSymbol: string
   baseToken: string
   oracleAddress: string
-  priceId: string
   treasury: string
   criticalReserveRatio: string
 }
@@ -43,7 +42,6 @@ export default function CreatePage() {
     protonSymbol: "",
     baseToken: "",
     oracleAddress: "",
-    priceId: "",
     treasury: address || "",
     criticalReserveRatio: "400",
   })
@@ -79,7 +77,6 @@ export default function CreatePage() {
            config.baseToken && 
            config.oracleAddress &&
            config.treasury &&
-           config.priceId &&
            config.criticalReserveRatio
   }
 
@@ -160,12 +157,6 @@ export default function CreatePage() {
       return
     }
 
-    const trimmedPriceId = config.priceId.trim()
-    if (!/^0x[0-9a-fA-F]{64}$/.test(trimmedPriceId)) {
-      toast.error("Price feed ID must be a 32-byte hex value")
-      return
-    }
-
     const treasuryAddress = config.treasury.trim()
     if (!/^0x[0-9a-fA-F]{40}$/.test(treasuryAddress)) {
       toast.error("Treasury address must be a 20-byte checksum address")
@@ -200,7 +191,6 @@ export default function CreatePage() {
           peggedAssetSymbol,
           baseToken as `0x${string}`,
           oracleAddress as `0x${string}`,
-          trimmedPriceId as `0x${string}`,
           protonName,
           protonSymbol,
           treasuryAddress as `0x${string}`,
@@ -321,7 +311,7 @@ export default function CreatePage() {
 
                 <div className="space-y-2">
                   <Label className="text-[11px] uppercase tracking-[0.4em] text-white/60">
-                    Oracle (Pyth) Address
+                    Oracle Adapter Address
                   </Label>
                   <Input
                     placeholder="0x..."
@@ -331,7 +321,7 @@ export default function CreatePage() {
                   />
                 </div>
 
-                <div className="grid gap-6 md:grid-cols-2">
+                <div className="grid gap-6">
                   <div className="space-y-2">
                     <Label className="text-[11px] uppercase tracking-[0.4em] text-white/60">
                       Critical Reserve Ratio (%)
@@ -344,17 +334,6 @@ export default function CreatePage() {
                       value={config.criticalReserveRatio}
                       onChange={(e) => updateConfig("criticalReserveRatio", e.target.value)}
                       className={inputClasses}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label className="text-[11px] uppercase tracking-[0.4em] text-white/60">
-                      Price Feed ID
-                    </Label>
-                    <Input
-                      value={config.priceId}
-                      placeholder="0x..."
-                      onChange={(e) => updateConfig("priceId", e.target.value)}
-                      className={`${inputClasses} font-mono text-xs`}
                     />
                   </div>
                 </div>

--- a/utils/abi/StableCoinFactory.ts
+++ b/utils/abi/StableCoinFactory.ts
@@ -27,6 +27,71 @@ export const StableCoinFactoryABI = [
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "EmptyBaseName",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyBaseSymbol",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyPegName",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyPegSymbol",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyProtonName",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyProtonSymbol",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyVaultName",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBase",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidCriticalReserveRatio",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidFissionFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidFusionFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidOracle",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTreasury",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -110,6 +175,12 @@ export const StableCoinFactoryABI = [
       },
       {
         "indexed": false,
+        "internalType": "address",
+        "name": "oracleAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
         "internalType": "uint256",
         "name": "fissionFee",
         "type": "uint256"
@@ -128,31 +199,6 @@ export const StableCoinFactoryABI = [
       }
     ],
     "name": "ReactorDeployed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "reactor",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "base",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "basePriceId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "ReactorDeployedWithOracle",
     "type": "event"
   },
   {
@@ -208,13 +254,8 @@ export const StableCoinFactoryABI = [
       },
       {
         "internalType": "address",
-        "name": "pythOracleParam",
+        "name": "oracleParam",
         "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "priceIdParam",
-        "type": "bytes32"
       },
       {
         "internalType": "string",


### PR DESCRIPTION
### Addressed Issues:

N/A — this PR updates the existing reactor creation flow to match the current generic oracle adapter architecture.


### Screenshots/Recordings:

**Before**
- Reactor creation was Pyth-specific and required both an Oracle address and a Price Feed ID.

<img width="2559" height="1325" alt="gold-backed-vault-setup-0817-2315" src="https://github.com/user-attachments/assets/3c6dc939-4938-4d60-b37b-a277ccd1521c" />

**After**
- Reactor creation now accepts an `IOracle` compatible adapter address.
- The Pyth-specific Price Feed ID field has been removed.

<img width="2560" height="1321" alt="gluon-vault-setup-0818-0007-1" src="https://github.com/user-attachments/assets/df2e0d3c-0f97-4574-a5e7-cdd349109c8e" />


### Additional Notes:

This PR establishes the base for the upcoming multi-oracle WebUI work.

The existing Create Reactor flow has been updated to match the current `StableCoinFactory` interface:
- updated the Factory ABI
- replaced the Pyth-specific oracle parameter with the generic oracle adapter parameter
- removed the obsolete `priceId` field, validation, and deployment argument
- updated the oracle field label to `Oracle Adapter Address`
- kept the rest of the existing Create Reactor flow unchanged

Provider-specific configuration for Chainlink, Orb, and other oracle providers is intentionally not included in this PR and will be handled separately.

Validation performed:
- `pnpm build` passes successfully
- `/create` was tested locally and the updated form renders correctly
- `git diff --check` passes

`pnpm exec tsc --noEmit` currently reports pre-existing TypeScript errors in unrelated files. No new TypeScript errors were observed in the files changed by this PR.


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle configuration now uses a single adapter address instead of a separate price feed ID.
  * Deployment results now identify the configured oracle address.

* **Bug Fixes**
  * Added clearer validation for names, oracle configuration, treasury, fees, base assets, and reserve ratios.
  * Simplified the critical reserve ratio section to a single-column layout.
  * Removed obsolete price feed configuration from the deployment flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->